### PR TITLE
Return status of command, not while loop

### DIFF
--- a/concurrent.lib.sh
+++ b/concurrent.lib.sh
@@ -315,6 +315,7 @@ concurrent() (
             while read -r meta; do
                 printf "meta:%d:%s\n" "${1}" "${meta}" >> "${4}"
             done
+            exit "${PIPESTATUS[0]}"
         )
         code=$?
         set -o errexit  # ...but other failures should


### PR DESCRIPTION
Without this,

    concurrent \
        - t true \
        - f false

will succeed.