### PR TITLE
makes bash-concurrent work in bash 5

### DIFF
--- a/concurrent.lib.sh
+++ b/concurrent.lib.sh
@@ -22,8 +22,8 @@ concurrent() (
     # Compatibility Check
     #
 
-    if [[ -z "${BASH_VERSINFO[@]}" || "${BASH_VERSINFO[0]}" -lt 4 || "${BASH_VERSINFO[1]}" -lt 2 ]]; then
-        __crt__error "Requires Bash version 4.2 for 'declare -g' (you have ${BASH_VERSION:-a different shell})"
+    if ! declare -g >/dev/null 2>&1; then
+        __crt__error "Requires at least Bash version 4.2 for 'declare -g' (you have ${BASH_VERSION:-a different shell})"
     fi
 
     #


### PR DESCRIPTION
fixes #34 by trying to run declare -g rather than parse bash version